### PR TITLE
Add `maxTransitiveDepth` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ libyear {
   
   // alternatively:
   validator = singleArtifactMustNotBeOlderThan(2.days)
+
+  // optional: limit the depth of the dependency traversal, default is 0 = only the root level, null = no limit
+  maxTransitiveDepth = 5
 }
 ```
 
@@ -45,6 +48,7 @@ libyear {
   configurations = ['compileClasspath']
   failOnError = true
   validator = allArtifactsCombinedMustNotBeOlderThan(days(5))
+  maxTransitiveDepth = 5
 }
 ```
 

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearExtension.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearExtension.kt
@@ -20,6 +20,8 @@ open class LibYearExtension {
 
   var validator: DependencyValidatorSpec = defaultValidator
 
+  var ignoreTransitive: Boolean = false
+
   var configurations: List<String> = defaultConfigurations
 
   // DSL for build script authors

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearExtension.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearExtension.kt
@@ -20,7 +20,7 @@ open class LibYearExtension {
 
   var validator: DependencyValidatorSpec = defaultValidator
 
-  var maxTransitiveDepth: Int = 100
+  var maxTransitiveDepth: Int? = 0
 
   var configurations: List<String> = defaultConfigurations
 

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearExtension.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearExtension.kt
@@ -20,7 +20,7 @@ open class LibYearExtension {
 
   var validator: DependencyValidatorSpec = defaultValidator
 
-  var ignoreTransitive: Boolean = false
+  var maxTransitiveDepth: Int = 100
 
   var configurations: List<String> = defaultConfigurations
 

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearPlugin.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearPlugin.kt
@@ -59,7 +59,7 @@ class LibYearPlugin : Plugin<Project> {
     val ageOracle = createOracle(project, extension)
     val validator = createValidator(project, extension)
     val visitor = ValidatingVisitor(project.logger, ageOracle, validator, ValidationConfig(failOnError = extension.failOnError))
-    DependencyTraversal.visit(resolvableDependencies.resolutionResult.root, visitor)
+    DependencyTraversal.visit(resolvableDependencies.resolutionResult.root, visitor, extension.ignoreTransitive)
     maybeReportFailure(project.logger, validator)
   }
 

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearPlugin.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearPlugin.kt
@@ -59,7 +59,7 @@ class LibYearPlugin : Plugin<Project> {
     val ageOracle = createOracle(project, extension)
     val validator = createValidator(project, extension)
     val visitor = ValidatingVisitor(project.logger, ageOracle, validator, ValidationConfig(failOnError = extension.failOnError))
-    DependencyTraversal.visit(resolvableDependencies.resolutionResult.root, visitor, extension.ignoreTransitive)
+    DependencyTraversal.visit(resolvableDependencies.resolutionResult.root, visitor, extension.maxTransitiveDepth)
     maybeReportFailure(project.logger, validator)
   }
 

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearReportTask.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearReportTask.kt
@@ -15,7 +15,7 @@ open class LibYearReportTask : DefaultTask() {
       .forEach {
         val ageOracle = createOracle(project, extension)
         val visitor = ReportingVisitor(project.logger, ageOracle)
-        DependencyTraversal.visit(it.incoming.resolutionResult.root, visitor)
+        DependencyTraversal.visit(it.incoming.resolutionResult.root, visitor, extension.ignoreTransitive)
         visitor.print()
       }
   }

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearReportTask.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearReportTask.kt
@@ -15,7 +15,7 @@ open class LibYearReportTask : DefaultTask() {
       .forEach {
         val ageOracle = createOracle(project, extension)
         val visitor = ReportingVisitor(project.logger, ageOracle)
-        DependencyTraversal.visit(it.incoming.resolutionResult.root, visitor, extension.ignoreTransitive)
+        DependencyTraversal.visit(it.incoming.resolutionResult.root, visitor, extension.maxTransitiveDepth)
         visitor.print()
       }
   }

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/traversal/DependencyTraversal.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/traversal/DependencyTraversal.kt
@@ -7,7 +7,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
 class DependencyTraversal private constructor(
   private val visitor: DependencyVisitor,
-  private val maxTransitiveDepth: Int
+  private val maxTransitiveDepth: Int?
 ) {
 
   private val seen = mutableSetOf<ComponentIdentifier>()
@@ -24,7 +24,7 @@ class DependencyTraversal private constructor(
       if (!visitor.canContinue()) return
 
       if (dependency is ResolvedDependencyResult) {
-        if (depth > maxTransitiveDepth) {
+        if (maxTransitiveDepth != null && depth > maxTransitiveDepth) {
           continue
         }
         nextComponents.add(dependency.selected)
@@ -42,7 +42,7 @@ class DependencyTraversal private constructor(
     fun visit(
       root: ResolvedComponentResult,
       visitor: DependencyVisitor,
-      maxTransitiveDepth: Int = 0
+      maxTransitiveDepth: Int? = null
     ): Unit = DependencyTraversal(visitor, maxTransitiveDepth).visit(root, depth = 0)
   }
 }

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/traversal/DependencyTraversal.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/traversal/DependencyTraversal.kt
@@ -12,7 +12,7 @@ class DependencyTraversal private constructor(
 
   private val seen = mutableSetOf<ComponentIdentifier>()
 
-  private fun visit(component: ComponentResult, level: Int = 0) {
+  private fun visit(component: ComponentResult, depth: Int = 0) {
     if (!seen.add(component.id)) return
 
     visitor.visitComponentResult(component)
@@ -24,7 +24,7 @@ class DependencyTraversal private constructor(
       if (!visitor.canContinue()) return
 
       if (dependency is ResolvedDependencyResult) {
-        if (level > maxTransitiveDepth) {
+        if (depth > maxTransitiveDepth) {
           continue
         }
         nextComponents.add(dependency.selected)
@@ -32,7 +32,7 @@ class DependencyTraversal private constructor(
     }
 
     for (nextComponent in nextComponents) {
-      visit(nextComponent, level + 1)
+      visit(nextComponent, depth + 1)
       if (!visitor.canContinue()) break
     }
   }
@@ -43,6 +43,6 @@ class DependencyTraversal private constructor(
       root: ResolvedComponentResult,
       visitor: DependencyVisitor,
       maxTransitiveDepth: Int = 0
-    ): Unit = DependencyTraversal(visitor, maxTransitiveDepth).visit(root, level = 0)
+    ): Unit = DependencyTraversal(visitor, maxTransitiveDepth).visit(root, depth = 0)
   }
 }


### PR DESCRIPTION
## What

Add a flag `maxTransitiveDepth` to allow folks to only get the libyears of the "root" dependencies they define in their project, or a X levels of transitive dependencies. Setting it to `0` means only root deps. `1` is root + their dependencies, etc.

## Why 
These are the dependency upgrades we have the most control over, and are also the ones tools like Renovate or Dependabot will inspect + recommend upgrades for. Knowing that my frameworks relies on a library that relies on a library 5 layers deep that is 10 years old doesn't really help me as much as knowing that my framework itself is 5 years old when there's a version avail that's 1 year old, etc.

Relevant Issue: https://github.com/f4lco/libyear-gradle-plugin/issues/15

## TODO:
- [x] Update README.md before merge if this implementation is acceptable
- [x] Add tests