### PR TITLE
Report the libyear output to JSON in `build/reports`

### DIFF
--- a/libyear-gradle-plugin/build.gradle.kts
+++ b/libyear-gradle-plugin/build.gradle.kts
@@ -98,6 +98,7 @@ tasks.withType(Test::class) {
   testLogging {
     events("started")
     showExceptions = true
+    showStandardStreams = true
   }
 }
 

--- a/libyear-gradle-plugin/build.gradle.kts
+++ b/libyear-gradle-plugin/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp:4.8.1")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.9.9")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.9")
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.9")
 
   testImplementation("com.squareup.okhttp3:mockwebserver:4.8.1")
   testImplementation("org.mockito:mockito-core:3.7.7")

--- a/libyear-gradle-plugin/src/functionalTest/kotlin/com/libyear/LibYearPluginTest.kt
+++ b/libyear-gradle-plugin/src/functionalTest/kotlin/com/libyear/LibYearPluginTest.kt
@@ -36,9 +36,24 @@ internal class LibYearPluginTest {
       .extracting { it?.outcome }.isEqualTo(TaskOutcome.FAILED)
   }
 
-  private fun withGradleRunner() = GradleRunner.create().apply {
+  @Test
+  fun testReportLibyear() {
+    setUpProject("valid.gradle.kts")
+    withGradleRunner("reportLibyear").build()
+    val libyearJsonFile = project.resolve("build/reports/libyear/libyear.json").toFile().readText()
+    val expectedJson = javaClass.getResourceAsStream("expectedReport.json")?.bufferedReader()?.use { it.readText() }
+
+    // Replace lagDays values with 0 using regex so reports match despite age
+    val lagDaysRegex = "\"lagDays\":\\s*\\d+".toRegex()
+    val normalizedLibyearJson = libyearJsonFile.replace(lagDaysRegex, "\"lagDays\": 0")
+    val normalizedExpectedJson = expectedJson?.replace(lagDaysRegex, "\"lagDays\": 0")
+
+    assertThat(normalizedLibyearJson).isEqualToIgnoringWhitespace(normalizedExpectedJson)
+  }
+
+  private fun withGradleRunner(command: String = "dependencies") = GradleRunner.create().apply {
     withProjectDir(project.toFile())
-    withArguments("dependencies")
+    withArguments(command)
     withPluginClasspath()
   }
 

--- a/libyear-gradle-plugin/src/functionalTest/resources/com/libyear/expectedReport.json
+++ b/libyear-gradle-plugin/src/functionalTest/resources/com/libyear/expectedReport.json
@@ -1,0 +1,38 @@
+{
+  "collected" : [ {
+    "module" : {
+      "version" : "1.9",
+      "module" : {
+        "group" : "org.apache.commons",
+        "name" : "commons-text"
+      },
+      "name" : "commons-text",
+      "group" : "org.apache.commons"
+    },
+    "lag_days" : 1361
+  }, {
+    "module" : {
+      "version" : "3.11",
+      "module" : {
+        "group" : "org.apache.commons",
+        "name" : "commons-lang3"
+      },
+      "name" : "commons-lang3",
+      "group" : "org.apache.commons"
+    },
+    "lag_days" : 1504
+  }, {
+    "module" : {
+      "version" : "4.4",
+      "module" : {
+        "group" : "org.apache.commons",
+        "name" : "commons-collections4"
+      },
+      "name" : "commons-collections4",
+      "group" : "org.apache.commons"
+    },
+    "lag_days" : 1806
+  } ],
+  "missing_info" : [ ],
+  "errors" : [ ]
+}

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearReportTask.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/LibYearReportTask.kt
@@ -17,6 +17,7 @@ open class LibYearReportTask : DefaultTask() {
         val visitor = ReportingVisitor(project.logger, ageOracle)
         DependencyTraversal.visit(it.incoming.resolutionResult.root, visitor)
         visitor.print()
+        visitor.saveReportToJson(project)
       }
   }
 }

--- a/libyear-gradle-plugin/src/main/kotlin/com/libyear/traversal/ReportingVisitor.kt
+++ b/libyear-gradle-plugin/src/main/kotlin/com/libyear/traversal/ReportingVisitor.kt
@@ -1,11 +1,15 @@
 package com.libyear.traversal
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.libyear.sourcing.VersionOracle
 import com.libyear.util.formatApproximate
+import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal
 import org.gradle.api.logging.Logger
+import java.io.File
 import java.time.Duration
 
 private data class ReportingInfo(
@@ -20,6 +24,8 @@ class ReportingVisitor(
 ) : DependencyVisitor(logger) {
 
   private val collected = mutableListOf<ReportingInfo>()
+  private val missingInfo = mutableListOf<ModuleVersionIdentifier>()
+  private val errors = mutableListOf<ModuleVersionIdentifier>()
 
   private val totalAge: Duration get() = collected.map { it.lag }.fold(Duration.ZERO, Duration::plus)
 
@@ -31,10 +37,14 @@ class ReportingVisitor(
     val age = ageOracle.get(module, repositoryName)
 
     age.onSuccess { info ->
-      info.update?.let { update ->
+      val update = info.update
+      if (update != null) {
         collected += ReportingInfo(module, update.lag, update.nextVersion)
+      } else {
+        missingInfo += module
       }
     }.onFailure {
+      errors += module
       logger.error("""Cannot determine dependency age for "$module" and repository "$repositoryName" (reason: ${it::class.simpleName}: ${it.message}).""")
     }
   }
@@ -47,10 +57,46 @@ class ReportingVisitor(
   }
 
   fun print() {
-    logger.lifecycle("Collected ${totalAge.formatApproximate()}  worth of libyears from ${collected.size} dependencies:")
+    if (missingInfo.isNotEmpty()) {
+      logger.lifecycle("Dependencies with no update information available:")
+      missingInfo.forEach { module ->
+        logger.lifecycle(" -> ${module.group}:${module.name}:${module.version}")
+      }
+    }
+
+    if (errors.isNotEmpty()) {
+      logger.lifecycle("Dependencies with errors during age determination:")
+      errors.forEach { module ->
+        logger.lifecycle(" -> ${module.group}:${module.name}:${module.version}")
+      }
+    }
+
+    if (missingInfo.isNotEmpty() || errors.isNotEmpty()) {
+      logger.lifecycle("") // Blank line
+    }
+
+    logger.lifecycle("Collected ${totalAge.formatApproximate()} worth of libyears from ${collected.size} dependencies:")
     collected.sortedWith(byAgeAndModule()).forEach { dep ->
       logger.lifecycle(" -> ${dep.lag.formatApproximate().padEnd(10)} from ${dep.module.module} (${dep.module.version} => ${dep.latestVersion})")
     }
+  }
+
+  fun saveReportToJson(project: Project) {
+    val report = mapOf(
+      "collected" to collected.map {
+        mapOf(
+          "module" to it.module,
+          "lag_days" to it.lag.toDays()
+        )
+      },
+      "missing_info" to missingInfo,
+      "errors" to errors
+    )
+    val objectMapper = ObjectMapper().registerKotlinModule()
+    val json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(report)
+    val reportFile = File(project.buildDir, "reports/libyear/libyear.json")
+    reportFile.parentFile.mkdirs()
+    reportFile.writeText(json)
   }
 
   private fun byAgeAndModule(): Comparator<ReportingInfo> = compareByDescending<ReportingInfo> { it.lag }.thenComparing(ReportingInfo::module, byModule())


### PR DESCRIPTION
This gets output in `build/reports/libyear/libyear.json`:
```
{
  "collected" : [ {
    "module" : {
      "version" : "1.9.20",
      "name" : "kotlin-stdlib-jdk8",
      "module" : {
        "group" : "org.jetbrains.kotlin",
        "name" : "kotlin-stdlib-jdk8"
      },
      "group" : "org.jetbrains.kotlin"
    },
    "lag_days" : 322
  }, {
    "module" : {
      "version" : "1.9.20",
      "name" : "kotlin-reflect",
      "module" : {
        "group" : "org.jetbrains.kotlin",
        "name" : "kotlin-reflect"
      },
      "group" : "org.jetbrains.kotlin"
    },
    "lag_days" : 322
  }],
  "missing_info" : [ {
    "version" : "2.2",
    "name" : "migbase64",
    "module" : {
      "group" : "com.brsanthu",
      "name" : "migbase64"
    },
    "group" : "com.brsanthu"
  }, {
    "version" : "8.0.33",
    "name" : "mysql-connector-java",
    "module" : {
      "group" : "mysql",
      "name" : "mysql-connector-java"
    },
    "group" : "mysql"
  }
}
```

I've also added `missingInfo` + `error` aggregation & printing because it's confusing when your project lists a root level dependency but the dep doesn't show up in your report.

## TODO: 
- [x] Add tests